### PR TITLE
Always link to latest javadocs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,21 +1,21 @@
 name: Build
-on: 
+on:
   workflow_dispatch:
 
 jobs:
   job:
-     runs-on: ubuntu-latest
-     steps: 
-     - name: Checkout
-       uses: actions/checkout@v1
-     - name: Setup Java
-       uses: actions/setup-java@v1
-       with:
-         java-version: '8'
-     - name: Script
-       run: ./generate-diff.sh
-     - name: Deploy
-       uses: JamesIves/github-pages-deploy-action@4.1.0
-       with:
-         branch: gh-pages
-         folder: output
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Setup Java
+      uses: actions/setup-java@v1
+      with:
+        java-version: '8'
+    - name: Script
+      run: ./generate-diff.sh
+    - name: Deploy
+      uses: JamesIves/github-pages-deploy-action@4.1.0
+      with:
+        branch: gh-pages
+        folder: output


### PR DESCRIPTION
Fixes #3

Also cleanup the script a bit to work with it easier, don't hate me @MiniDigger 

ubuntu-latest should have JQ installed, so there's no additional install steps necessary: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#tools